### PR TITLE
Remove broken txn_end()

### DIFF
--- a/lib/DBIx/Handler.pm
+++ b/lib/DBIx/Handler.pm
@@ -243,7 +243,6 @@ sub txn {
 sub txn_begin    { $_[0]->txn_manager->txn_begin    }
 sub txn_rollback { $_[0]->txn_manager->txn_rollback }
 sub txn_commit   { $_[0]->txn_manager->txn_commit   }
-sub txn_end      { $_[0]->txn_manager->txn_end      }
 
 1;
 
@@ -317,10 +316,6 @@ commit transaction.
 =item $handler->txn_rollback
 
 rollback transaction.
-
-=item $handler->txn_end
-
-finish transaction.
 
 =item $handler->in_txn
 


### PR DESCRIPTION
DBIx::TransactionManager has _txn_end() method but doen't have txn_end() method.
DBIx::Handler has a wrapper function for the latter method.
So I delete it.
